### PR TITLE
修复Firefox下Google重定向失效问题

### DIFF
--- a/AC-Baidu-SoGou-Google-NoRedirect.user.js
+++ b/AC-Baidu-SoGou-Google-NoRedirect.user.js
@@ -2868,6 +2868,7 @@ body[google] {
               let one = resultNodes[i];
               one.setAttribute("onmousedown", ""); // 谷歌去重定向干扰
               one.setAttribute("target", "_blank"); // 谷歌链接新标签打开
+              one.setAttribute("data-jsarwt", "0"); // Firefox谷歌去重定向干扰
             }
           } catch (e) {
             console.log(e);


### PR DESCRIPTION
fix #476 #532
在Windows 10下Firefox 112版本测试通过