### PR TITLE
修复block按钮未阻止事件冒泡

### DIFF
--- a/AC-Baidu-SoGou-Google-NoRedirect.user.js
+++ b/AC-Baidu-SoGou-Google-NoRedirect.user.js
@@ -2451,6 +2451,7 @@
       }
       CONST.saveBlockRule()
       env.stopPropagation();
+      env.preventDefault()
     }
     _getBlockBtnTitle(host) {
       return `点击即可屏蔽 ${ host } 放开，需要在自定义中手动配置放开`;


### PR DESCRIPTION
点击包裹在a标签下的block按钮时会跳转