### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/ac-baidu/doc/docs/pages/home/start.md
+++ b/ac-baidu/doc/docs/pages/home/start.md
@@ -38,7 +38,7 @@ head:
 
 如果你的网络能打开下面应用商店的地址，则直接安装即可：
 
-- [Tampermonkey - Chrome 应用商店](https://chrome.google.com/webstore/detail/dhdgffkkebhmkfjojejmpbldmpobfkfo)
+- [Tampermonkey - Chrome 应用商店](https://chromewebstore.google.com/detail/dhdgffkkebhmkfjojejmpbldmpobfkfo)
 - [Tampermonkey - Edge 应用商店](https://microsoftedge.microsoft.com/addons/detail/iikmkjmpaadaobahmlepeloendndfphd)
 - [Tampermonkey - Firefox 应用商店](https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/)
 - [Tampermonkey - Safari 应用商店](https://apps.apple.com/us/app/tampermonkey/id1482490089)

--- a/help.md
+++ b/help.md
@@ -12,7 +12,7 @@
 |  QQ浏览器 |  qqbrowser://extensions/search?key=Tampermonkey |
 |  UC浏览器 |  离线安装包 [Tampermonkey.crx](https://open-1252026789.cos.ap-beijing.myqcloud.com/Tampermonkey.crx?q-sign-algorithm=sha1&q-ak=AKID5vs71lFeyZfPygxk2FKr00awLkM2CtH9&q-sign-time=1552783829;1552785629&q-key-time=1552783829;1552785629&q-header-list=&q-url-param-list=&q-signature=f6af0eeaa1aec2eeb91ec733010f3a55f945876d&x-cos-security-token=4ea51c804f012501a972cdb19e18a2f6560452af10001) |
 |  遨游浏览器 |  http://extension.maxthon.cn/detail/index.php?view_id=1680&category_id=10 |
-|  Chrome浏览器 |  https://chrome.google.com/webstore/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo |
+|  Chrome浏览器 |  https://chromewebstore.google.com/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo |
 |  火狐浏览器 |  https://addons.mozilla.org/zh-CN/firefox/addon/tampermonkey/ |
 |  Microsoft Edge |  https://www.microsoft.com/store/p/tampermonkey/9nblggh5162s |
 |  其他浏览器 |  同UC |


### PR DESCRIPTION
## Summary
- Updated 2 Chrome Web Store URLs from `chrome.google.com/webstore/detail/` to `chromewebstore.google.com/detail/`
- Google migrated the Chrome Web Store to a new domain; the old URLs redirect but should be updated for consistency

## Files changed
- `help.md`
- `ac-baidu/doc/docs/pages/home/start.md`