### PR TITLE
Fix(bing): Restore centered multi-column layout

### DIFF
--- a/AC-Baidu-SoGou-Google-NoRedirect.user.js
+++ b/AC-Baidu-SoGou-Google-NoRedirect.user.js
@@ -1917,6 +1917,50 @@
           CONST.cssAutoInsert.add("multiPageStyle", CONST.adsCSSList.multiPageStyle)
         }
       }
+      // bing原生样式会把 b_wide 拉成整行、把 b_algo 固定到第 1 列
+      if (+CONST.curConfig.adsStyleMode >= 3) {
+        CONST.cssAutoInsert.add(
+          "bingGridAlignFix",
+          `
+            body #b_content > main {
+              width: 73vw !important;
+              max-width: none !important;
+            }
+
+            body #b_content .b_widemop_layout {
+              display: block !important;
+              width: 100% !important;
+              max-width: none !important;
+            }
+
+            body #b_content .b_widemop_rr {
+              display: none !important;
+            }
+
+            #b_content .b_widemop_layout > #b_results {
+              width: 100% !important;
+              grid-area: auto !important;
+              grid-template-rows: none !important;
+              grid-auto-rows: auto !important;
+              grid-auto-flow: row !important;
+            }
+
+            #b_content #b_results {
+              align-items: start !important;
+            }
+
+            #b_content #b_results > li:not(.b_pag):not(.b_msg):not(#b_msg):not(#mfa_root) {
+              align-self: start !important;
+              min-width: 0 !important;
+              grid-area: auto !important;
+              grid-column: auto / span 1 !important;
+              grid-row: auto !important;
+              width: 98% !important;
+              max-width: 100% !important;
+            }
+          `
+        )
+      }
 
       CONST.cssAutoInsert.add("styleLogo", ".minidiv #logo img{width: 100px;height: unset;margin-top: 0.3rem;} body.purecss-mode:before{display: none;}")
       CONST.cssAutoInsert.add("specialBAIDU", ".opr-recommends-merge-imgtext{display:none!important;}.res_top_banner{display:none!important;}.headBlock, body>div.result-op{display:none;}")

--- a/AC-Baidu-SoGou-Google-NoRedirect.user.js
+++ b/AC-Baidu-SoGou-Google-NoRedirect.user.js
@@ -1917,51 +1917,6 @@
           CONST.cssAutoInsert.add("multiPageStyle", CONST.adsCSSList.multiPageStyle)
         }
       }
-      // bing原生样式会把 b_wide 拉成整行、把 b_algo 固定到第 1 列
-      if (+CONST.curConfig.adsStyleMode >= 3) {
-        CONST.cssAutoInsert.add(
-          "bingGridAlignFix",
-          `
-            body #b_content > main {
-              width: 73vw !important;
-              max-width: none !important;
-            }
-
-            body #b_content .b_widemop_layout {
-              display: block !important;
-              width: 100% !important;
-              max-width: none !important;
-            }
-
-            body #b_content .b_widemop_rr {
-              display: none !important;
-            }
-
-            #b_content .b_widemop_layout > #b_results {
-              width: 100% !important;
-              grid-area: auto !important;
-              grid-template-rows: none !important;
-              grid-auto-rows: auto !important;
-              grid-auto-flow: row !important;
-            }
-
-            #b_content #b_results {
-              align-items: start !important;
-            }
-
-            #b_content #b_results > li:not(.b_pag):not(.b_msg):not(#b_msg):not(#mfa_root) {
-              align-self: start !important;
-              min-width: 0 !important;
-              grid-area: auto !important;
-              grid-column: auto / span 1 !important;
-              grid-row: auto !important;
-              width: 98% !important;
-              max-width: 100% !important;
-            }
-          `
-        )
-      }
-
       CONST.cssAutoInsert.add("styleLogo", ".minidiv #logo img{width: 100px;height: unset;margin-top: 0.3rem;} body.purecss-mode:before{display: none;}")
       CONST.cssAutoInsert.add("specialBAIDU", ".opr-recommends-merge-imgtext{display:none!important;}.res_top_banner{display:none!important;}.headBlock, body>div.result-op{display:none;}")
       CONST.cssAutoInsert.add("animationStyle", `

--- a/newcss/bingTwoPageStyle.less
+++ b/newcss/bingTwoPageStyle.less
@@ -17,6 +17,44 @@
   }
 }
 
+// bing原生样式会把 b_wide 拉成整行、把 b_algo 固定到第 1 列
+body #b_content > main {
+  width: 73vw !important;
+  max-width: none !important;
+}
+
+body #b_content .b_widemop_layout {
+  display: block !important;
+  width: 100% !important;
+  max-width: none !important;
+}
+
+body #b_content .b_widemop_rr {
+  display: none !important;
+}
+
+#b_content .b_widemop_layout > #b_results {
+  width: 100% !important;
+  grid-area: auto !important;
+  grid-template-rows: none !important;
+  grid-auto-rows: auto !important;
+  grid-auto-flow: row !important;
+}
+
+#b_content #b_results {
+  align-items: start !important;
+}
+
+#b_content #b_results > li:not(.b_pag):not(.b_msg):not(#b_msg):not(#mfa_root) {
+  align-self: start !important;
+  min-width: 0 !important;
+  grid-area: auto !important;
+  grid-column: auto / span 1 !important;
+  grid-row: auto !important;
+  width: 98% !important;
+  max-width: 100% !important;
+}
+
 .carousel .items {
   max-width: 72vw;
   overflow-x: scroll;


### PR DESCRIPTION
## 问题说明
bing新版页面引入了.b_widemop_layout和subgrid布局：

- .b_wide默认占满整行，导致结果块被拉长
- .b_algo默认固定在第 1 列，导致右列为空
- #b_results被设置为 73vw，但外层main仍保持旧宽度，整体右偏移

## 改动内容
修改位置：[`dataChangeFireCallback()`](https://github.com/SiIverAsh/GM_script/blob/fix_bing_layout_bug/AC-Baidu-SoGou-Google-NoRedirect.user.js#L1920-L1963)
- 改了 main、.b_widemop_layout和#b_results 的宽度，修复整体偏移
- 隐藏bing新版右栏
- 重置subgrid行布局
- 清除bing对 .b_wide 和 .b_algo的固定列定位
- 在双列和多列（adsStyleMode >= 3生效。

